### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,23 +9,23 @@ JSON-API
     :target: https://coveralls.io/r/pavlov99/jsonapi
     :alt: Coverage Status
 
-.. image:: https://pypip.in/v/jsonapi/badge.png
+.. image:: https://img.shields.io/pypi/v/jsonapi.svg
     :target: https://crate.io/packages/jsonapi
     :alt: Version
 
-.. image:: https://pypip.in/download/jsonapi/badge.svg
+.. image:: https://img.shields.io/pypi/dm/jsonapi.svg
     :target: https://pypi.python.org/pypi/jsonapi/
     :alt: Downloads
 
-.. image:: https://pypip.in/format/jsonapi/badge.png
+.. image:: https://img.shields.io/pypi/format/jsonapi.svg
     :target: https://pypi.python.org/pypi/jsonapi/
     :alt: Download format
 
-.. image:: https://pypip.in/license/jsonapi/badge.png
+.. image:: https://img.shields.io/pypi/l/jsonapi.svg
     :target: https://pypi.python.org/pypi/jsonapi/
     :alt: License
 
-.. image:: https://pypip.in/status/jsonapi/badge.svg
+.. image:: https://img.shields.io/pypi/status/jsonapi.svg
     :target: https://pypi.python.org/pypi/jsonapi/
     :alt: Development Status
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20jsonapi))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `jsonapi`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.